### PR TITLE
fix(openapi): add migration to change 'trigger_properties' to object

### DIFF
--- a/openapi/migrations/2023-12-22-trigger-properties-must-be-an-object.ts
+++ b/openapi/migrations/2023-12-22-trigger-properties-must-be-an-object.ts
@@ -1,0 +1,16 @@
+import spec from '../spec.json';
+import { traverse, writeSpec } from '../../utils';
+
+const TRIGGER_PROPERTIES = 'trigger_properties';
+
+traverse(spec, '', null, (value, key, parent) => {
+  if (key === TRIGGER_PROPERTIES && value === '') {
+    parent[TRIGGER_PROPERTIES] = {};
+  }
+
+  if (key === TRIGGER_PROPERTIES && value?.type === 'string') {
+    parent[TRIGGER_PROPERTIES].type = 'object';
+  }
+});
+
+writeSpec(spec);

--- a/openapi/spec.json
+++ b/openapi/spec.json
@@ -3456,7 +3456,7 @@
                     {
                       "user_alias": "example_alias",
                       "external_user_id": "external_user_identifier",
-                      "trigger_properties": "",
+                      "trigger_properties": {},
                       "canvas_entry_properties": {}
                     }
                   ],
@@ -3524,7 +3524,7 @@
                       "properties": {
                         "user_alias": { "type": "string" },
                         "external_user_id": { "type": "string" },
-                        "trigger_properties": { "type": "string" },
+                        "trigger_properties": { "type": "object" },
                         "canvas_entry_properties": { "type": "object" }
                       }
                     }
@@ -4091,7 +4091,7 @@
                 "example": {
                   "campaign_id": "campaign_identifier",
                   "send_id": "send_identifier",
-                  "trigger_properties": "",
+                  "trigger_properties": {},
                   "broadcast": false,
                   "audience": {
                     "AND": [
@@ -4147,7 +4147,7 @@
                         "alias_label": "example_label"
                       },
                       "external_user_id": "external_user_identifier",
-                      "trigger_properties": "",
+                      "trigger_properties": {},
                       "send_to_existing_only": true,
                       "attributes": { "first_name": "Alex" }
                     }
@@ -4156,7 +4156,7 @@
                 "properties": {
                   "campaign_id": { "type": "string" },
                   "send_id": { "type": "string" },
-                  "trigger_properties": { "type": "string" },
+                  "trigger_properties": { "type": "object" },
                   "broadcast": { "type": "boolean" },
                   "audience": {
                     "type": "object",
@@ -4175,7 +4175,7 @@
                           }
                         },
                         "external_user_id": { "type": "string" },
-                        "trigger_properties": { "type": "string" },
+                        "trigger_properties": { "type": "object" },
                         "send_to_existing_only": { "type": "boolean" },
                         "attributes": {
                           "type": "object",
@@ -4290,7 +4290,7 @@
                         "alias_label": "example_label"
                       },
                       "external_user_id": "user_identifier",
-                      "trigger_properties": "",
+                      "trigger_properties": {},
                       "canvas_entry_properties": "",
                       "send_to_existing_only": true,
                       "attributes": { "first_name": "Alex" }
@@ -4324,7 +4324,7 @@
                           }
                         },
                         "external_user_id": { "type": "string" },
-                        "trigger_properties": { "type": "string" },
+                        "trigger_properties": { "type": "object" },
                         "canvas_entry_properties": { "type": "string" },
                         "send_to_existing_only": { "type": "boolean" },
                         "attributes": {


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(openapi): add migration to change `trigger_properties` to object

Relates to https://github.com/braze-community/braze-php/issues/37

## What is the current behavior?

`trigger_properties` is string

## What is the new behavior?

`trigger_properties` is object

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation