### PR TITLE
fix(openapi): don't set default value for `should_inline_css`

### DIFF
--- a/openapi/migrations/2025-06-04-should-inline-css.ts
+++ b/openapi/migrations/2025-06-04-should-inline-css.ts
@@ -1,0 +1,13 @@
+import spec from '../spec.json';
+import { traverse, writeSpec } from '../../utils';
+
+const should_inline_css = 'should_inline_css';
+
+traverse(spec, '', null, (value, key, parent) => {
+  // delete default value since parameter is optional
+  if (key === should_inline_css && value === false) {
+    delete parent[should_inline_css];
+  }
+});
+
+writeSpec(spec);

--- a/openapi/spec.json
+++ b/openapi/spec.json
@@ -5755,8 +5755,7 @@
                   "body": "string",
                   "plaintext_body": "string",
                   "preheader": "string",
-                  "tags": ["string"],
-                  "should_inline_css": true
+                  "tags": ["string"]
                 },
                 "properties": {
                   "template_name": { "type": "string" },
@@ -5866,8 +5865,7 @@
                   "body": "string",
                   "plaintext_body": "string",
                   "preheader": "string",
-                  "tags": ["string"],
-                  "should_inline_css": true
+                  "tags": ["string"]
                 },
                 "properties": {
                   "email_template_id": { "type": "string" },

--- a/postman/collection.json
+++ b/postman/collection.json
@@ -3171,7 +3171,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\"template_name\":\"string\",\"subject\":\"string\",\"body\":\"string\",\"plaintext_body\":\"string\",\"preheader\":\"string\",\"tags\":[\"string\"],\"should_inline_css\":true}"
+                  "raw": "{\"template_name\":\"string\",\"subject\":\"string\",\"body\":\"string\",\"plaintext_body\":\"string\",\"preheader\":\"string\",\"tags\":[\"string\"],\"should_inline_css\":false}"
                 },
                 "url": {
                   "raw": "https://{{instance_url}}/templates/email/create?template_name&subject&body&plaintext_body&preheader&tags&should_inline_css",
@@ -3238,7 +3238,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\"email_template_id\":\"string\",\"template_name\":\"string\",\"subject\":\"string\",\"body\":\"string\",\"plaintext_body\":\"string\",\"preheader\":\"string\",\"tags\":[\"string\"],\"should_inline_css\":true}",
+                  "raw": "{\"email_template_id\":\"string\",\"template_name\":\"string\",\"subject\":\"string\",\"body\":\"string\",\"plaintext_body\":\"string\",\"preheader\":\"string\",\"tags\":[\"string\"],\"should_inline_css\":false}",
                   "options": { "raw": { "language": "json" } }
                 },
                 "url": {

--- a/postman/migrations/2023-08-12-fix-request-body.ts
+++ b/postman/migrations/2023-08-12-fix-request-body.ts
@@ -167,7 +167,7 @@ traverse(collection, '', null, (value, key, parent) => {
         plaintext_body: 'string',
         preheader: 'string',
         tags: ['string'],
-        should_inline_css: true,
+        should_inline_css: false,
       }));
 
     case 'Update email template':
@@ -179,7 +179,7 @@ traverse(collection, '', null, (value, key, parent) => {
         plaintext_body: 'string',
         preheader: 'string',
         tags: ['string'],
-        should_inline_css: true,
+        should_inline_css: false,
       }));
 
     case 'Identify users':


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(openapi): don't set default value for `should_inline_css`

## What is the current behavior?

`should_inline_css` defaults to true

## What is the new behavior?

`should_inline_css` default value not set as it's optional

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation