### PR TITLE
fix(openapi): correct schema type of `should_inline_css`

### DIFF
--- a/openapi/migrations/2025-06-04-should-inline-css.ts
+++ b/openapi/migrations/2025-06-04-should-inline-css.ts
@@ -4,9 +4,13 @@ import { traverse, writeSpec } from '../../utils';
 const should_inline_css = 'should_inline_css';
 
 traverse(spec, '', null, (value, key, parent) => {
-  // delete default value since parameter is optional
-  if (key === should_inline_css && value === false) {
-    delete parent[should_inline_css];
+  // fix schema type
+  if (
+    key === 'name' &&
+    value === should_inline_css &&
+    parent.schema?.type === 'string'
+  ) {
+    parent.schema.type = 'boolean';
   }
 });
 

--- a/openapi/spec.json
+++ b/openapi/spec.json
@@ -5755,7 +5755,8 @@
                   "body": "string",
                   "plaintext_body": "string",
                   "preheader": "string",
-                  "tags": ["string"]
+                  "tags": ["string"],
+                  "should_inline_css": true
                 },
                 "properties": {
                   "template_name": { "type": "string" },
@@ -5822,7 +5823,7 @@
           {
             "name": "should_inline_css",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": { "type": "boolean" },
             "description": "(Optional) Boolean"
           }
         ],
@@ -5865,7 +5866,8 @@
                   "body": "string",
                   "plaintext_body": "string",
                   "preheader": "string",
-                  "tags": ["string"]
+                  "tags": ["string"],
+                  "should_inline_css": true
                 },
                 "properties": {
                   "email_template_id": { "type": "string" },
@@ -5940,7 +5942,7 @@
           {
             "name": "should_inline_css",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": { "type": "boolean" },
             "description": "(Optional) Boolean"
           }
         ],

--- a/postman/collection.json
+++ b/postman/collection.json
@@ -3171,7 +3171,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\"template_name\":\"string\",\"subject\":\"string\",\"body\":\"string\",\"plaintext_body\":\"string\",\"preheader\":\"string\",\"tags\":[\"string\"],\"should_inline_css\":false}"
+                  "raw": "{\"template_name\":\"string\",\"subject\":\"string\",\"body\":\"string\",\"plaintext_body\":\"string\",\"preheader\":\"string\",\"tags\":[\"string\"],\"should_inline_css\":true}"
                 },
                 "url": {
                   "raw": "https://{{instance_url}}/templates/email/create?template_name&subject&body&plaintext_body&preheader&tags&should_inline_css",
@@ -3238,7 +3238,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\"email_template_id\":\"string\",\"template_name\":\"string\",\"subject\":\"string\",\"body\":\"string\",\"plaintext_body\":\"string\",\"preheader\":\"string\",\"tags\":[\"string\"],\"should_inline_css\":false}",
+                  "raw": "{\"email_template_id\":\"string\",\"template_name\":\"string\",\"subject\":\"string\",\"body\":\"string\",\"plaintext_body\":\"string\",\"preheader\":\"string\",\"tags\":[\"string\"],\"should_inline_css\":true}",
                   "options": { "raw": { "language": "json" } }
                 },
                 "url": {

--- a/postman/migrations/2023-08-12-fix-request-body.ts
+++ b/postman/migrations/2023-08-12-fix-request-body.ts
@@ -167,7 +167,7 @@ traverse(collection, '', null, (value, key, parent) => {
         plaintext_body: 'string',
         preheader: 'string',
         tags: ['string'],
-        should_inline_css: false,
+        should_inline_css: true,
       }));
 
     case 'Update email template':
@@ -179,7 +179,7 @@ traverse(collection, '', null, (value, key, parent) => {
         plaintext_body: 'string',
         preheader: 'string',
         tags: ['string'],
-        should_inline_css: false,
+        should_inline_css: true,
       }));
 
     case 'Identify users':


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(openapi): correct schema type of `should_inline_css`

## What is the current behavior?

Schema type of `should_inline_css` is string

## What is the new behavior?

Schema type of `should_inline_css` is boolean and bring back example

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation