### PR TITLE
fix(openapi): change `canvas_entry_properties` type from string to object

### DIFF
--- a/openapi/migrations/2025-06-05-fix-canvas-entry-properties.ts
+++ b/openapi/migrations/2025-06-05-fix-canvas-entry-properties.ts
@@ -1,0 +1,22 @@
+import spec from '../spec.json';
+import { traverse, writeSpec } from '../../utils';
+
+const canvas_entry_properties = 'canvas_entry_properties';
+
+/**
+ * @see {@link https://github.com/braze-community/braze-php/issues/152}
+ */
+traverse(spec, '', null, (value, key, parent) => {
+  if (key !== canvas_entry_properties) {
+    return;
+  }
+
+  // `canvas_entry_properties` is an object
+  if (typeof value === 'string') {
+    parent[key] = {};
+  } else if (value?.type === 'string' || value?.type === 'object') {
+    parent[key] = { type: 'object' };
+  }
+});
+
+writeSpec(spec);

--- a/openapi/spec.json
+++ b/openapi/spec.json
@@ -4301,7 +4301,7 @@
                       },
                       "external_user_id": "user_identifier",
                       "trigger_properties": {},
-                      "canvas_entry_properties": "",
+                      "canvas_entry_properties": {},
                       "send_to_existing_only": true,
                       "attributes": { "first_name": "Alex" }
                     }
@@ -4309,13 +4309,7 @@
                 },
                 "properties": {
                   "canvas_id": { "type": "string" },
-                  "canvas_entry_properties": {
-                    "type": "object",
-                    "properties": {
-                      "product_name": { "type": "string" },
-                      "product_price": { "type": "number" }
-                    }
-                  },
+                  "canvas_entry_properties": { "type": "object" },
                   "broadcast": { "type": "boolean" },
                   "audience": {
                     "type": "object",
@@ -4337,7 +4331,7 @@
                         },
                         "external_user_id": { "type": "string" },
                         "trigger_properties": { "type": "object" },
-                        "canvas_entry_properties": { "type": "string" },
+                        "canvas_entry_properties": { "type": "object" },
                         "send_to_existing_only": { "type": "boolean" },
                         "attributes": {
                           "type": "object",


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(openapi): change `canvas_entry_properties` type from string to object

Relates to https://github.com/braze-community/braze-php/issues/152

## What is the current behavior?

`canvas_entry_properties` type is sometimes a string

## What is the new behavior?

`canvas_entry_properties` type is always an object

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation