### PR TITLE
fix(openapi): add requestBody to DELETE `/catalogs/{catalog_name}/items`

### DIFF
--- a/openapi/migrations/2023-08-18-fix-json-schema.ts
+++ b/openapi/migrations/2023-08-18-fix-json-schema.ts
@@ -4,9 +4,8 @@ import { traverse, writeSpec } from '../../utils';
 traverse(spec, '', null, (value, key, parent) => {
   switch (key) {
     case '/catalogs/{catalog_name}/items':
-      ['put'].forEach((method) => {
-        delete getSchemaProperties(key, method, value).items.items.properties;
-      });
+      delete getSchemaProperties(key, 'put', value).items.items.properties;
+      value.delete.requestBody = value.patch.requestBody;
       break;
 
     case '/catalogs/{catalog_name}/items/{item_id}':
@@ -16,12 +15,9 @@ traverse(spec, '', null, (value, key, parent) => {
       break;
 
     case '/users/track':
-      ['post'].forEach((method) => {
-        delete getSchemaProperties(key, method, value).attributes.items
-          .properties;
-        delete getSchemaProperties(key, method, value).purchases.items
-          .properties;
-      });
+      delete getSchemaProperties(key, 'post', value).attributes.items
+        .properties;
+      delete getSchemaProperties(key, 'post', value).purchases.items.properties;
       break;
   }
 

--- a/openapi/spec.json
+++ b/openapi/spec.json
@@ -373,6 +373,25 @@
           "404": { "$ref": "#/components/responses/NotFound" },
           "429": { "$ref": "#/components/responses/TooManyRequests" },
           "500": { "$ref": "#/components/responses/InternalServerError" }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "example": { "items": [{ "id": "restaurant1" }] },
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": { "id": { "type": "string" } }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       },
       "patch": {


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(openapi): add requestBody to DELETE `/catalogs/{catalog_name}/items`

Relates to https://github.com/braze-community/braze-php/issues/160

## What is the current behavior?

No requestBody for DELETE `/catalogs/{catalog_name}/items`

## What is the new behavior?

Same requestBody as PATCH for DELETE `/catalogs/{catalog_name}/items`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation